### PR TITLE
#29 - Fix multi-link string parsing

### DIFF
--- a/src/metadata_cache.ts
+++ b/src/metadata_cache.ts
@@ -16,26 +16,28 @@ function addFrontmatterLinksToCache(file: TFile, frontmatter: any) {
     for (let key of Object.keys(frontmatter)) {
         const value = frontmatter[key];
         if (typeof(value) === "string") {
-            const match: RegExpMatchArray | null = value.match(/\[\[(.+)\|.+\]\]/m) || value.match(/\[\[(.+)\]\]/m) || value.match(/\[.+\]\((.+)\)/m);
-            
-            if (!match) { continue; }
-            let href = match[1];
+            const pattern = /\[\[(.+?\]?)(?:\|(.+?))?\]\]|\[(.+?)\]\((.+?)\)/gm;
+            let matches = [...value.matchAll(pattern)];
+            matches.forEach((match) => {
+                if (!match) { return; }
+                let href = (match[4] === undefined ? match[1] : match[4]);
 
-            if (isUri(href)) { continue; }
+                if (isUri(href)) { return; }
 
-            let f = app.metadataCache.getFirstLinkpathDest(href, "");
-            let links: Record<string, Record<string, number>>;
-            if (f instanceof TFile) {
-                href = f.path;
-                links = app.metadataCache.resolvedLinks;
-            } else {
-                links = app.metadataCache.unresolvedLinks;
-            }
+                let f = app.metadataCache.getFirstLinkpathDest(href, "");
+                let links: Record<string, Record<string, number>>;
+                if (f instanceof TFile) {
+                    href = f.path;
+                    links = app.metadataCache.resolvedLinks;
+                } else {
+                    links = app.metadataCache.unresolvedLinks;
+                }
 
-            if (links[file.path][href]) {
-                links[file.path][href] += 1;
-            } else {
-                links[file.path][href] = 1;
+                if (links[file.path][href]) {
+                    links[file.path][href] += 1;
+                } else {
+                    links[file.path][href] = 1;
+                }
             }
         } else if (typeof(value) === "object") {
             addFrontmatterLinksToCache(file, value);


### PR DESCRIPTION
This should hopefully fix the multi-link string parsing issue (#29). Turns out I'm way better at JS than TS though, so I haven't even figured out how to build the TS code.

I tested the JS code on the following YAML (both with quotes on/off), and then ported everything to TS:
```yaml
link: http://example.com
link-with-quotes: "http://example.com"
wikilink: "[[Wikilink]]"
external-markdown-link: "[External Markdown Link](http://example.com)"
internal-markdown-link: "[Internal Markdown Link](Internal)"
multi-link: "Text [[Link1]] more text [[Link2|alias]] more text"
multi-link2: "Text [External Markdown Link](http://example.com) more text [[Another link]] Test"
wierd-link: "[[Test (foo)]]"
weird-link2: "[[Test [bar]]]"
```
(Would be useful to have these as a standard test case perhaps?)

![image](https://github.com/Trikzon/obsidian-frontmatter-links/assets/591175/382682f1-2e2c-4624-bce7-b649c57e4a40)
![image](https://github.com/Trikzon/obsidian-frontmatter-links/assets/591175/2f1b6c90-cf2a-4b8f-baaf-bdd3abbc0f20)

If I messed up the TS code somehow, feel free to fix it, or to disregard this PR entirely.